### PR TITLE
Added baseUrl into tsconfig, even it's not required old version of Je…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": "./",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Added baseUrl into tsconfig, even it's not required old version of JetBrains IDE doesn't resolve paths without it