### PR TITLE
fix: return empty response for missing third-party integration API key

### DIFF
--- a/app/api/ph-dev-tools/route.ts
+++ b/app/api/ph-dev-tools/route.ts
@@ -9,6 +9,10 @@ export async function GET() {
 
   const PH_ACCESS_TOKEN = process.env.PH_ACCESS_TOKEN;
 
+  if (!PH_ACCESS_TOKEN) {
+    return NextResponse.json({ posts: [] });
+  }
+
   const config = {
     headers: {
       Authorization: `Bearer ${PH_ACCESS_TOKEN}`,

--- a/app/blog/sitemap.xml/route.tsx
+++ b/app/blog/sitemap.xml/route.tsx
@@ -2,7 +2,10 @@ const BASE_URL = 'https://devhunt.org';
 
 async function getSitemap() {
   const key = process.env.SEOBOT_API_KEY;
-  if (!key) throw Error('SEOBOT_API_KEY enviroment variable must be set');
+  if (!key) {
+    console.warn('SEOBOT_API_KEY enviroment variable must be set');
+    return { articles: [], categories: [], tags: [] };
+  }
 
   try {
     const res = await fetch(`https://app.seobotai.com/api/sitemap?key=${key}`, { cache: 'no-store' });


### PR DESCRIPTION
After following the bare-minimum steps to self-host DevHunt, it was throwing some errors at the built steps for missing some API keys.

This PR fixes the above said issue, by returning the empty response.