### PR TITLE
Prevent updating date launch after the launch start

### DIFF
--- a/app/account/tools/edit/[id]/page.tsx
+++ b/app/account/tools/edit/[id]/page.tsx
@@ -76,6 +76,7 @@ export default () => {
   const [weekValue, setWeekValue] = useState<string | number>('');
 
   const [launchEnd, setLaunchDate] = useState<string>();
+  const [launchStart, setLaunchStart] = useState<string>();
 
   useEffect(() => {
     pricingTypesList.then(types => {
@@ -98,6 +99,7 @@ export default () => {
       setImagePreview(data?.asset_urls as string[]);
       setPaid(data?.isPaid as boolean);
       setLaunchDate(data?.launch_end as string);
+      setLaunchStart(data?.launch_start as string);
     });
   }, []);
 
@@ -341,7 +343,7 @@ export default () => {
             {new Date(launchEnd as string) > new Date() && (
               <div>
                 <div className="relative mt-4 mb-3">
-                  {isPaid ? (
+                  {isPaid && new Date(launchStart as string) > new Date() ? (
                     <SelectLaunchDate
                       validate={{
                         ...register('week', { required: true, onChange: e => setWeekValue(e.target.value) }),

--- a/app/account/tools/new/page.tsx
+++ b/app/account/tools/new/page.tsx
@@ -325,7 +325,9 @@ export default () => {
         setValue('tool_website', '');
         setValue('tool_description', product.description);
         setLogoPreview(product.thumbnail.url);
+        setLogoFile(product.thumbnail.url);
         setImagePreview(product.media.map((item: { url: string }) => item.url));
+        setImageFile(product.media.map((item: { url: string }) => item.url));
         // Close modal and show success message
         setIsPhModalOpen(false);
         setPhSlug('');

--- a/app/api/ph-dev-tools/get-website-url/[url]/route.ts
+++ b/app/api/ph-dev-tools/get-website-url/[url]/route.ts
@@ -40,16 +40,18 @@ function extractHostAndPath(url: string): { host: string; path: string } {
 export async function GET(req: NextRequest, { params }: RouteParams) {
   const { url } = params;
 
-  console.log('Website URL', url);
+  console.log('Website URL', url.replace(/\?.*$/, ''));
 
   const requests = (website: string) => {
     // Return a promise for each request
     return new Promise((resolve, reject) => {
       // Perform the request asynchronously
-      request({ url: website, followRedirect: false }, function (err, res, body) {
+      request({ url: website.replace(/\?.*$/, ''), followRedirect: false }, function (err, res, body) {
         if (err) {
           reject(err);
         } else {
+          console.log('res.headers', res.headers);
+
           resolve(extractLink(extractHostAndPath(res.headers.location as string).host));
         }
       });


### PR DESCRIPTION
- Upgraded lockfile version to 9.0 and updated various package versions in pnpm-lock.yaml.
- Refactored the tool submission page to remove unnecessary API calls and set default values for tool website.
- Adjusted the best-dev-tools page to correct the development server URL and simplified website handling.
-Remove PH redirect url handler for now
- Modified usermaven initialization logic to only create the client if the USER_MAVEN_KEY is present.