### PR TITLE
fix: enhance error handling and submission logic in tool creation

### DIFF
--- a/components/ui/SelectLaunchDate/index.tsx
+++ b/components/ui/SelectLaunchDate/index.tsx
@@ -26,7 +26,7 @@ export default ({ label, value, className = '', validate, setAllWeeks = () => {}
 
       const productsService = new ProductsService(createBrowserClient());
       const startWeek = await productsService.getWeekNumber(startDate, 2);
-      const result = await productsService.getProductsCountByWeek(startWeek + 1, startWeek + 55, startDate.getFullYear());
+      const result = await productsService.getProductsCountByWeek(startWeek + 1, startWeek + 104, startDate.getFullYear());
       setWeeks(result);
       setAllWeeks(result);
       // const x = weeks.filter(item => item.week == 11)


### PR DESCRIPTION
- Wrapped the submission logic in a try-catch block to handle errors gracefully.
- Added checks for available launch dates based on the selected submission type, providing user feedback when no free dates are available.
- Updated the week range for product count retrieval to extend the search period from 55 to 104 weeks.