### PR TITLE
fix: enhance week count retrieval and submission logic for launch dates

### DIFF
--- a/app/account/tools/new/page.tsx
+++ b/app/account/tools/new/page.tsx
@@ -241,41 +241,47 @@ export default () => {
 
         // Re-fetch fresh week counts to avoid stale-data race condition where the
         // queue fills up between page load and submission time.
+        // Search 260 weeks (~5 years) so a free slot is always found even if the
+        // near-term queue fills up. getProductsCountByWeek handles multi-year traversal.
         const freshFetchDate = new Date();
         const freshStartWeek = await productService.getWeekNumber(freshFetchDate, 2);
-        const freshWeeks = await productService.getProductsCountByWeek(freshStartWeek + 1, freshStartWeek + 104, freshFetchDate.getFullYear());
+        const freshWeeks = await productService.getProductsCountByWeek(freshStartWeek + 1, freshStartWeek + 260, freshFetchDate.getFullYear());
 
         const availableDate = findNearestAvailableDate(freshWeeks as []);
-        if (submitType == 'free' && !availableDate) {
+
+        // Re-check the selected week's count from fresh data.
+        // If the user picked a free week (normal) but it filled up since page load,
+        // downgrade them to the nearest free slot automatically.
+        const freshSelectedWeek = freshWeeks.find(w => w.week === launchWeek);
+        const selectedWeekIsFull = !freshSelectedWeek || freshSelectedWeek.count >= 15;
+        const effectiveSubmitType = submitType === 'normal' && selectedWeekIsFull ? 'free' : submitType;
+
+        if (effectiveSubmitType === 'free' && !availableDate) {
           setLaunching(false);
-          if (allWeeks.length === 0) {
-            alert('Launch dates are still loading. Please wait a moment and try again.');
-          } else {
-            alert('No free launch dates found (all weeks are full). Please choose a paid week instead.');
-          }
+          alert('No free launch dates available right now. Please choose a paid week instead.');
           return;
         }
-        if (submitType == 'free') {
+
+        if (effectiveSubmitType === 'free') {
           launchData.launch_date = formatDate(availableDate!.startDate as string);
           launchData.launch_start = formatDate(availableDate!.startDate as string);
           launchData.launch_end = formatDate(availableDate!.endDate as string);
           launchData.week = availableDate!.week as number;
-        } else if (submitType == 'paid') {
-          // Hold the product in the nearest free slot until payment is confirmed.
-          // activate-launch will move it to the chosen paid week (stored in paid_launch_date).
+        } else if (effectiveSubmitType === 'paid') {
+          // Park in the nearest free slot; activate-launch moves it to the paid
+          // week (stored in paid_launch_date) once payment is confirmed.
           if (availableDate) {
             launchData.launch_date = formatDate(availableDate.startDate as string);
             launchData.launch_start = formatDate(availableDate.startDate as string);
             launchData.launch_end = formatDate(availableDate.endDate as string);
             launchData.week = availableDate.week as number;
           } else {
-            // No free slot found anywhere – fall back to the paid week itself.
             launchData.launch_date = weekData?.startDate as string;
             launchData.launch_start = weekData?.startDate as string;
             launchData.launch_end = weekData?.endDate;
             launchData.week = weekData?.week;
           }
-        } else if (submitType == 'normal') {
+        } else if (effectiveSubmitType === 'normal') {
           launchData.launch_date = weekData?.startDate as string;
           launchData.launch_start = weekData?.startDate as string;
           launchData.launch_end = weekData?.endDate;

--- a/utils/supabase/services/products.ts
+++ b/utils/supabase/services/products.ts
@@ -163,35 +163,25 @@ export default class ProductsService extends BaseDbService {
       }));
     };
 
-    // Determine how many weeks actually exist in the current year for start_day = 2
-    const currentYearWeeks = await this.getWeeks(year, 2);
-    const weeksInCurrentYear = currentYearWeeks.length;
+    // Walk year-by-year so the full requested range is always covered,
+    // regardless of how many calendar-year boundaries it crosses.
+    const results: { week: number; startDate: Date; endDate: Date; count: number }[] = [];
+    let currentYear = year;
+    let currentStartWeek = startWeek;
+    let weeksLeft = endWeek - startWeek + 1;
 
-    let results: {
-      week: number;
-      startDate: Date;
-      endDate: Date;
-      count: number;
-    }[] = [];
+    while (weeksLeft > 0 && currentYear <= year + 5) {
+      const weeksInYear = (await this.getWeeks(currentYear, 2)).length;
+      const currentEndWeek = Math.min(currentStartWeek + weeksLeft - 1, weeksInYear);
 
-    if (endWeek <= weeksInCurrentYear) {
-      // Everything fits into the current year
-      results = await queryProductsCount(startWeek, endWeek, year);
-    } else {
-      // Split the query into current year and next year based on real week counts
-      const resultsCurrentYear = await queryProductsCount(startWeek, weeksInCurrentYear, year);
+      if (currentStartWeek <= weeksInYear) {
+        const batch = await queryProductsCount(currentStartWeek, currentEndWeek, currentYear);
+        results.push(...batch);
+        weeksLeft -= currentEndWeek - currentStartWeek + 1;
+      }
 
-      const overflowWeeks = endWeek - weeksInCurrentYear;
-
-      // Clamp overflow to the actual number of weeks in the next year as well
-      const nextYearWeeks = await this.getWeeks(year + 1, 2);
-      const weeksInNextYear = nextYearWeeks.length;
-      const overflowInNextYear = Math.min(overflowWeeks, weeksInNextYear);
-
-      const resultsNextYear =
-        overflowInNextYear > 0 ? await queryProductsCount(1, overflowInNextYear, year + 1) : [];
-
-      results = [...resultsCurrentYear, ...resultsNextYear];
+      currentStartWeek = 1;
+      currentYear++;
     }
 
     return results;


### PR DESCRIPTION
fix: enhance week count retrieval and submission logic for launch dates

- Updated the product count retrieval to search for available weeks over a 5-year span, ensuring a free slot is always found.
- Improved the submission logic to automatically downgrade to the nearest free slot if the selected week is full.
- Refined error handling to provide clearer alerts when no free launch dates are available.