### PR TITLE
Submit: Beam — Privacy-first web analytics on Cloudflare Workers

### DIFF
--- a/submissions/beam-analytics.json
+++ b/submissions/beam-analytics.json
@@ -1,0 +1,13 @@
+{
+  "name": "Beam",
+  "slug": "beam-analytics",
+  "slogan": "Privacy-first web analytics. No cookies, no consent banners.",
+  "demo_url": "https://beam.keylightdigital.dev",
+  "github_url": "https://github.com/scobb",
+  "description": "Beam is a lightweight, cookie-free, GDPR-compliant web analytics service built on Cloudflare Workers. Add a single 2KB script tag and get a clean dashboard with pageviews, referrers, countries, browsers, and devices \u2014 without cookies, consent banners, or sending data to Google. Free tier: 1 site, 5K pageviews/month. Pro: $5/month for unlimited sites and 100K pageviews.",
+  "pricing_type": "freemium",
+  "categories": [
+    "Analytics",
+    "Monitoring"
+  ]
+}


### PR DESCRIPTION
## Beam — Privacy-First Web Analytics

Beam is a lightweight, cookie-free, GDPR-compliant web analytics service built on Cloudflare Workers.

- **URL:** https://beam-privacy.com
- **Categories:** Analytics, Monitoring
- **Pricing:** Free (1 site, 50K pageviews/mo) + Pro ($5/mo, unlimited sites)
- **Tech:** Cloudflare Workers + D1 + KV, Hono framework, vanilla JS tracking script (<2KB)

**Why Beam?**
- No cookies → no consent banner required
- GDPR/CCPA/PECR compliant out of the box
- Under 2KB tracking script (no dependencies)
- Clean dashboard: pageviews, referrers, countries, browsers, devices
- Public shareable dashboards
- CSV data export (Pro)