### PR TITLE
feat: add domainFrom field to email sender configuration

### DIFF
--- a/app/api/new-tools-launch-reminder-email/route.ts
+++ b/app/api/new-tools-launch-reminder-email/route.ts
@@ -67,6 +67,7 @@ export async function GET(req: Request) {
         topicName: 'DevHunt',
         sender: {
           name: 'DevHunt',
+          domainFrom: 'hey',
           from: 'hey@devhunt.org',
           emailFrom: 'hey@devhunt.org',
           replyTo: 'hey@devhunt.org',

--- a/app/api/top-3-past-winners-email/route.ts
+++ b/app/api/top-3-past-winners-email/route.ts
@@ -57,6 +57,7 @@ export async function GET(req: Request) {
         topicName: 'DevHunt',
         sender: {
           name: 'DevHunt',
+          domainFrom: 'hey',
           emailFrom: 'hey@devhunt.org',
           from: 'hey@devhunt.org',
           replyTo: 'hey@devhunt.org',

--- a/app/api/top-3-winners-email/route.ts
+++ b/app/api/top-3-winners-email/route.ts
@@ -55,6 +55,7 @@ export async function GET(req: Request) {
         topicName: 'DevHunt',
         sender: {
           name: 'DevHunt',
+          domainFrom: 'hey',
           emailFrom: 'hey@devhunt.org',
           from: 'hey@devhunt.org',
           replyTo: 'hey@devhunt.org',


### PR DESCRIPTION
feat: add domainFrom field to email sender configuration

- Added the domainFrom field with a value of 'hey' to the sender configuration in the new tools launch reminder, top 3 past winners, and top 3 winners email routes, standardizing the email sender setup.