### PR TITLE
fix: update unsubscribe link format in email templates

### DIFF
--- a/utils/email-templates/new-tools-launch-reminder-email-template.ts
+++ b/utils/email-templates/new-tools-launch-reminder-email-template.ts
@@ -1550,7 +1550,7 @@ export default `
                                                             font-weight: normal;
                                                             text-decoration: underline;
                                                           "
-                                                          href="{{unsubscribeLink}}?redirectTo=https://devhunt.org/newsletter/unsubscribe"
+                                                          href="{{unsubscribeLink}}&redirectTo=https://devhunt.org/newsletter/unsubscribe"
                                                           >Unsubscribe</a
                                                         >
                                                       </p></span

--- a/utils/email-templates/top-3-winners-email-template.ts
+++ b/utils/email-templates/top-3-winners-email-template.ts
@@ -1204,7 +1204,7 @@ export default `
                                                             font-weight: normal;
                                                             text-decoration: underline;
                                                           "
-                                                          href="{{unsubscribeLink}}?redirectTo=https://devhunt.org/newsletter/unsubscribe"
+                                                          href="{{unsubscribeLink}}&redirectTo=https://devhunt.org/newsletter/unsubscribe"
                                                           >Unsubscribe</a
                                                         >
                                                       </p></span

--- a/utils/email-templates/winners-personal-congrats-email-template.ts
+++ b/utils/email-templates/winners-personal-congrats-email-template.ts
@@ -737,7 +737,7 @@ export default `
                                                             font-weight: normal;
                                                             text-decoration: underline;
                                                           "
-                                                          href="{{unsubscribeLink}}?redirectTo=https://devhunt.org/newsletter/unsubscribe"
+                                                          href="{{unsubscribeLink}}&redirectTo=https://devhunt.org/newsletter/unsubscribe"
                                                           >Unsubscribe</a
                                                         >
                                                       </p></span


### PR DESCRIPTION
fix: update unsubscribe link format in email templates

- Changed the unsubscribe link in the new tools launch reminder, top 3 winners, and personal congratulations email templates to use '&' instead of '?' for the redirect parameter, ensuring proper URL formatting.