### PR TITLE
feat: implement email sponsor ad editor

### DIFF
--- a/app/api/email-sponsor-ad/route.ts
+++ b/app/api/email-sponsor-ad/route.ts
@@ -1,0 +1,100 @@
+import {
+  type EmailSponsorAdConfig,
+  getEmailSponsorAdConfig,
+  isLocalEmailAdEditorEnabled,
+  renderEmailSponsorAdPreview,
+  resetEmailSponsorAdConfig,
+  saveEmailSponsorAdConfig,
+} from '@/utils/email-templates/email-sponsor-ad';
+import { NextResponse } from 'next/server';
+
+function unauthorized() {
+  return new NextResponse('This editor is only available in local development.', { status: 403 });
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function normalizeConfig(body: Partial<EmailSponsorAdConfig>): EmailSponsorAdConfig | null {
+  const bannerImageUrl = body.bannerImageUrl?.trim();
+  const bannerLinkUrl = body.bannerLinkUrl?.trim();
+  const title = body.title?.trim();
+  const description = body.description?.trim();
+  const ctaLinkUrl = body.ctaLinkUrl?.trim();
+  const ctaText = body.ctaText?.trim();
+
+  if (!bannerImageUrl || !bannerLinkUrl || !title || !description || !ctaLinkUrl || !ctaText) {
+    return null;
+  }
+
+  if (!isValidUrl(bannerImageUrl) || !isValidUrl(bannerLinkUrl) || !isValidUrl(ctaLinkUrl)) {
+    return null;
+  }
+
+  return {
+    bannerImageUrl,
+    bannerLinkUrl,
+    title,
+    description,
+    ctaLinkUrl,
+    ctaText,
+  };
+}
+
+export async function GET(req: Request) {
+  if (!isLocalEmailAdEditorEnabled()) {
+    return unauthorized();
+  }
+
+  const { searchParams } = new URL(req.url);
+  if (searchParams.get('preview') === '1') {
+    return new NextResponse(renderEmailSponsorAdPreview(), {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+      },
+    });
+  }
+
+  return NextResponse.json(getEmailSponsorAdConfig());
+}
+
+export async function POST(req: Request) {
+  if (!isLocalEmailAdEditorEnabled()) {
+    return unauthorized();
+  }
+
+  const body = (await req.json()) as Partial<EmailSponsorAdConfig>;
+  const config = normalizeConfig(body);
+
+  if (!config) {
+    return NextResponse.json({ error: 'Please fill in all fields with valid URLs.' }, { status: 400 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  if (searchParams.get('preview') === '1') {
+    return new NextResponse(renderEmailSponsorAdPreview(config), {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+      },
+    });
+  }
+
+  saveEmailSponsorAdConfig(config);
+
+  return NextResponse.json({ success: true, config });
+}
+
+export async function DELETE() {
+  if (!isLocalEmailAdEditorEnabled()) {
+    return unauthorized();
+  }
+
+  const config = resetEmailSponsorAdConfig();
+  return NextResponse.json({ success: true, config });
+}

--- a/app/email-sponsor-ad/page.tsx
+++ b/app/email-sponsor-ad/page.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import Button from '@/components/ui/Button/Button';
+import Input from '@/components/ui/Input';
+import Label from '@/components/ui/Label/Label';
+import LabelError from '@/components/ui/LabelError/LabelError';
+import Textarea from '@/components/ui/Textarea';
+import { IconLoading } from '@/components/Icons';
+import fileUploader from '@/utils/supabase/fileUploader';
+import { type EmailSponsorAdConfig } from '@/utils/email-templates/email-sponsor-ad';
+import axios from 'axios';
+import { type ChangeEvent, useEffect, useState } from 'react';
+
+const emptyConfig: EmailSponsorAdConfig = {
+  bannerImageUrl: '',
+  bannerLinkUrl: '',
+  title: '',
+  description: '',
+  ctaLinkUrl: '',
+  ctaText: 'Learn More ›',
+};
+
+export default function EmailSponsorAdPage() {
+  const [config, setConfig] = useState<EmailSponsorAdConfig>(emptyConfig);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [previewHtml, setPreviewHtml] = useState('');
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+  const [isUnavailable, setIsUnavailable] = useState(false);
+
+  const refreshPreview = async (nextConfig: EmailSponsorAdConfig) => {
+    setIsPreviewLoading(true);
+    try {
+      const res = await axios.post('/api/email-sponsor-ad?preview=1', nextConfig, { responseType: 'text' });
+      setPreviewHtml(res.data);
+    } catch {
+      setPreviewHtml('');
+    } finally {
+      setIsPreviewLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    axios
+      .get('/api/email-sponsor-ad')
+      .then(res => {
+        setConfig(res.data);
+        refreshPreview(res.data);
+        setIsLoading(false);
+      })
+      .catch(err => {
+        if (err.response?.status === 403) {
+          setIsUnavailable(true);
+        } else {
+          setError('Could not load the current ad settings.');
+        }
+        setIsLoading(false);
+      });
+  }, []);
+
+  const handleUploadBanner = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !file.type.includes('image')) return;
+
+    setIsUploading(true);
+    setError('');
+    fileUploader({ files: file, options: 'w=600' }).then(data => {
+      if (data?.file) {
+        setConfig(current => {
+          const nextConfig = { ...current, bannerImageUrl: data.file };
+          refreshPreview(nextConfig);
+          return nextConfig;
+        });
+      } else {
+        setError('Image upload failed. Please try again.');
+      }
+      setIsUploading(false);
+    });
+  };
+
+  const handleReset = async () => {
+    const confirmed = window.confirm('Reset the ad back to the original ListingBott version? This will overwrite your saved changes.');
+    if (!confirmed) return;
+
+    setIsResetting(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const res = await axios.delete('/api/email-sponsor-ad');
+      setConfig(res.data.config);
+      setSuccess('Reset to the original ad.');
+      await refreshPreview(res.data.config);
+    } catch (err: any) {
+      setError(err.response?.data?.error || 'Could not reset the ad.');
+    } finally {
+      setIsResetting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      await axios.post('/api/email-sponsor-ad', config);
+      setSuccess('Saved. The launch reminder email will use this ad on the next send.');
+      await refreshPreview(config);
+    } catch (err: any) {
+      setError(err.response?.data?.error || 'Could not save changes. Please check your inputs.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <section className="container-custom-screen py-16 flex justify-center">
+        <IconLoading className="w-8 h-8 text-orange-500" />
+      </section>
+    );
+  }
+
+  if (isUnavailable) {
+    return (
+      <section className="container-custom-screen py-16 max-w-2xl">
+        <h1 className="text-xl text-slate-50 font-semibold">Email sponsor ad editor</h1>
+        <p className="mt-4 text-slate-400">This page is only available when running the app locally in development mode.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className=" max-w-7xl mx-auto py-10">
+      <div className="mb-8">
+        <h1 className="text-xl text-slate-50 font-semibold">Email sponsor ad editor</h1>
+        <p className="mt-2 text-slate-400">
+          Update the sponsored ad block in the launch reminder newsletter. Changes apply locally and are saved to{' '}
+          <code className="text-slate-300">data/email-sponsor-ad.json</code>.
+        </p>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <div className="space-y-6 rounded-xl border border-slate-700 bg-slate-800/40 p-6">
+          <div>
+            <Label>Banner image</Label>
+            <p className="text-sm text-slate-400 mt-1">Recommended size: 600x300 pixels.</p>
+            <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center">
+              <label
+                htmlFor="banner-upload"
+                className="relative block w-full max-w-[300px] aspect-[2/1] cursor-pointer overflow-hidden rounded-lg border border-dashed border-slate-600 bg-slate-900"
+              >
+                {config.bannerImageUrl ? (
+                  <img src={config.bannerImageUrl} alt="Banner preview" className="h-full w-full object-cover" />
+                ) : (
+                  <span className="flex h-full items-center justify-center text-sm text-slate-500">No banner yet</span>
+                )}
+                {isUploading ? <IconLoading className="absolute inset-0 m-auto text-orange-500" /> : null}
+              </label>
+              <div>
+                <Button
+                  type="button"
+                  className="bg-slate-800 hover:bg-slate-800/50 text-xs"
+                  onClick={() => document.getElementById('banner-upload')?.click()}
+                >
+                  Upload banner
+                </Button>
+                <input id="banner-upload" type="file" accept="image/*" className="sr-only" onChange={handleUploadBanner} />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <Label>Banner link URL</Label>
+            <Input
+              className="w-full mt-2"
+              placeholder="https://example.com/"
+              value={config.bannerLinkUrl}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setConfig(current => ({ ...current, bannerLinkUrl: e.target.value }))}
+            />
+            <p className="text-sm text-slate-500 mt-1">Where users go when they click the banner image.</p>
+          </div>
+
+          <div>
+            <Label>Title</Label>
+            <Input
+              className="w-full mt-2"
+              placeholder="Submit Website To Directories with ListingBott"
+              value={config.title}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setConfig(current => ({ ...current, title: e.target.value }))}
+            />
+          </div>
+
+          <div>
+            <Label>Description</Label>
+            <Textarea
+              className="w-full h-32 mt-2"
+              placeholder="Short description shown under the title"
+              value={config.description}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setConfig(current => ({ ...current, description: e.target.value }))}
+            />
+          </div>
+
+          <div>
+            <Label>Button link URL</Label>
+            <Input
+              className="w-full mt-2"
+              placeholder="https://example.com/"
+              value={config.ctaLinkUrl}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setConfig(current => ({ ...current, ctaLinkUrl: e.target.value }))}
+            />
+          </div>
+
+          <div>
+            <Label>Button text</Label>
+            <Input
+              className="w-full mt-2"
+              placeholder="Learn More ›"
+              value={config.ctaText}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setConfig(current => ({ ...current, ctaText: e.target.value }))}
+            />
+          </div>
+
+          <LabelError>{error}</LabelError>
+          {success ? <p className="text-sm text-green-400">{success}</p> : null}
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Button type="button" className="w-full sm:flex-1" isLoad={isSaving} onClick={handleSave}>
+              Save changes
+            </Button>
+            <Button type="button" variant="shiny" className="w-full sm:flex-1" isLoad={isResetting} onClick={handleReset}>
+              Reset to original ad
+            </Button>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-slate-700 bg-slate-800/40 p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h2 className="text-sm font-medium text-slate-200">Live preview</h2>
+            <Button
+              type="button"
+              variant="shiny"
+              className="text-xs px-3 py-1.5"
+              isLoad={isPreviewLoading}
+              onClick={() => refreshPreview(config)}
+            >
+              Refresh preview
+            </Button>
+          </div>
+          <iframe
+            title="Email ad preview"
+            srcDoc={previewHtml}
+            className="w-full min-h-[520px] rounded-lg border border-slate-700 bg-[#1e293b]"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/data/email-sponsor-ad.json
+++ b/data/email-sponsor-ad.json
@@ -1,0 +1,8 @@
+{
+  "bannerImageUrl": "https://e.sensorpro.net/organization/devhunt/Images/listingbott_banner-2.png",
+  "bannerLinkUrl": "https://e.sensorpro.net/run/Url.aspx?m1=DZ.cDUKBhlmH3BaI2T2yTJcPnofJ.HvA8MXi2au8ybQ9CiQVLPztuY.M.Q5ftKxOSZXE4Dv1u-o_hdtd_etha7ae|CjfKiQr3IiFVHIyO-ckQX9..79LMMnnDpOmJ2x1wyeNmiP-t516OELLPrORZ61TF_hdtd_zd&d2=&l1=1085951",
+  "title": "Submit Website To Directories with ListingBott",
+  "description": "ListingBott - your SaaS, tool, product, newsletter, or blog listed on 100+ directories in one click, saving you days of work to focus on more creative tasks.",
+  "ctaLinkUrl": "https://e.sensorpro.net/run/Url.aspx?m1=DZ.cDUKBhlmH3BaI2T2yTJcPnofJ.HvA8MXi2au8ybQ9CiQVLPztuY.M.Q5ftKxOSZXE4Dv1u-o_hdtd_etha7ae|CjfKiQr3IiFVHIyO-ckQX9..79LMMnnDpOmJ2x1wyeNmiP-t516OELLPrORZ61TF_hdtd_zd&d2=&l1=1085951",
+  "ctaText": "Learn More ›"
+}

--- a/utils/email-templates/email-sponsor-ad.ts
+++ b/utils/email-templates/email-sponsor-ad.ts
@@ -1,0 +1,82 @@
+import baseTemplate from '@/utils/email-templates/new-tools-launch-reminder-email-template';
+import fs from 'fs';
+import path from 'path';
+
+export type EmailSponsorAdConfig = {
+  bannerImageUrl: string;
+  bannerLinkUrl: string;
+  title: string;
+  description: string;
+  ctaLinkUrl: string;
+  ctaText: string;
+};
+
+const ORIGINAL_TRACKING_URL =
+  'https://e.sensorpro.net/run/Url.aspx?m1=DZ.cDUKBhlmH3BaI2T2yTJcPnofJ.HvA8MXi2au8ybQ9CiQVLPztuY.M.Q5ftKxOSZXE4Dv1u-o_hdtd_etha7ae|CjfKiQr3IiFVHIyO-ckQX9..79LMMnnDpOmJ2x1wyeNmiP-t516OELLPrORZ61TF_hdtd_zd&d2=&l1=1085951';
+
+export const DEFAULT_EMAIL_SPONSOR_AD: EmailSponsorAdConfig = {
+  bannerImageUrl: 'https://e.sensorpro.net/organization/devhunt/Images/listingbott_banner-2.png',
+  bannerLinkUrl: ORIGINAL_TRACKING_URL,
+  title: 'Submit Website To Directories with ListingBott',
+  description:
+    'ListingBott - your SaaS, tool, product, newsletter, or blog listed on 100+ directories in one click, saving you days of work to focus on more creative tasks.',
+  ctaLinkUrl: ORIGINAL_TRACKING_URL,
+  ctaText: 'Learn More ›',
+};
+
+const CONFIG_PATH = path.join(process.cwd(), 'data/email-sponsor-ad.json');
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+export function isLocalEmailAdEditorEnabled(): boolean {
+  return process.env.NODE_ENV === 'development';
+}
+
+export function getEmailSponsorAdConfig(): EmailSponsorAdConfig {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    return { ...DEFAULT_EMAIL_SPONSOR_AD, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT_EMAIL_SPONSOR_AD;
+  }
+}
+
+export function saveEmailSponsorAdConfig(config: EmailSponsorAdConfig): void {
+  fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+}
+
+export function resetEmailSponsorAdConfig(): EmailSponsorAdConfig {
+  saveEmailSponsorAdConfig(DEFAULT_EMAIL_SPONSOR_AD);
+  return DEFAULT_EMAIL_SPONSOR_AD;
+}
+
+export function applyEmailSponsorAd(template: string, config: EmailSponsorAdConfig = getEmailSponsorAdConfig()): string {
+  return template
+    .replace(/\{\{adBannerImageUrl\}\}/g, escapeHtml(config.bannerImageUrl))
+    .replace(/\{\{adBannerLinkUrl\}\}/g, escapeHtml(config.bannerLinkUrl))
+    .replace(/\{\{adTitle\}\}/g, escapeHtml(config.title))
+    .replace(/\{\{adDescription\}\}/g, escapeHtml(config.description))
+    .replace(/\{\{adCtaLinkUrl\}\}/g, escapeHtml(config.ctaLinkUrl))
+    .replace(/\{\{adCtaText\}\}/g, escapeHtml(config.ctaText));
+}
+
+export const SPONSOR_AD_START_MARKER = '<!-- START OF SPONSOR AD -->';
+export const SPONSOR_AD_END_MARKER = '<!-- END OF SPONSOR AD -->';
+
+export function extractEmailSponsorAdBlock(template: string): string {
+  const start = template.indexOf(SPONSOR_AD_START_MARKER);
+  const end = template.indexOf(SPONSOR_AD_END_MARKER);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('Email template missing sponsor ad markers');
+  }
+  return template.slice(start + SPONSOR_AD_START_MARKER.length, end).trim();
+}
+
+export function renderEmailSponsorAdPreview(config?: EmailSponsorAdConfig): string {
+  const template = applyEmailSponsorAd(baseTemplate, config ?? getEmailSponsorAdConfig());
+  const block = extractEmailSponsorAdBlock(template);
+  return `<!DOCTYPE html><html><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /></head><body style="margin:0;background-color:#1e293b;">${block}</body></html>`;
+}

--- a/utils/email-templates/new-tools-launch-reminder-email-template.ts
+++ b/utils/email-templates/new-tools-launch-reminder-email-template.ts
@@ -908,6 +908,7 @@ export default `
         </tr>
       </tbody>
     </table>
+    <!-- START OF SPONSOR AD -->
     <table
       id="Layout56"
       class="ReadMsgBody tgOuter"
@@ -968,7 +969,7 @@ export default `
                           >
                             <span class="mcEditImg" style="position: relative"
                               ><a
-                                href="https://e.sensorpro.net/run/Url.aspx?m1=DZ.cDUKBhlmH3BaI2T2yTJcPnofJ.HvA8MXi2au8ybQ9CiQVLPztuY.M.Q5ftKxOSZXE4Dv1u-o_hdtd_etha7ae|CjfKiQr3IiFVHIyO-ckQX9..79LMMnnDpOmJ2x1wyeNmiP-t516OELLPrORZ61TF_hdtd_zd&d2=&l1=1085951"
+                                href="{{adBannerLinkUrl}}"
                                 target="_blank"
                                 rel="noopener"
                                 ><img
@@ -981,7 +982,7 @@ export default `
                                     min-width: 600px;
                                     max-height: 300px;
                                   "
-                                  src="https://e.sensorpro.net/organization/devhunt/Images/listingbott_banner-2.png"
+                                  src="{{adBannerImageUrl}}"
                                   alt=""
                                   width="600"
                                   height="300"
@@ -1010,10 +1011,7 @@ export default `
                                 color: rgb(241, 245, 249);
                               "
                               spellcheck="false"
-                              ><strong
-                                >Submit Website To Directories with
-                                ListingBott</strong
-                              ></span
+                              ><strong>{{adTitle}}</strong></span
                             >
                           </td>
                         </tr>
@@ -1039,10 +1037,7 @@ export default `
                                 color: rgb(255, 255, 255);
                               "
                               spellcheck="false"
-                              >ListingBott - your SaaS, tool, product,
-                              newsletter, or blog listed on 100+ directories in
-                              one click, saving you days of work to focus on
-                              more creative tasks.</span
+                              >{{adDescription}}</span
                             >
                           </td>
                         </tr>
@@ -1105,11 +1100,11 @@ export default `
                                                 position: relative;
                                               "
                                               spellcheck="false"
-                                              href="https://e.sensorpro.net/run/Url.aspx?m1=DZ.cDUKBhlmH3BaI2T2yTJcPnofJ.HvA8MXi2au8ybQ9CiQVLPztuY.M.Q5ftKxOSZXE4Dv1u-o_hdtd_etha7ae|CjfKiQr3IiFVHIyO-ckQX9..79LMMnnDpOmJ2x1wyeNmiP-t516OELLPrORZ61TF_hdtd_zd&d2=&l1=1085951"
+                                              href="{{adCtaLinkUrl}}"
                                               target="_blank"
                                               rel="noopener noreferrer"
                                               title=""
-                                              >Learn More ›</a
+                                              >{{adCtaText}}</a
                                             >
                                           </td>
                                         </tr>
@@ -1132,6 +1127,7 @@ export default `
         </tr>
       </tbody>
     </table>
+    <!-- END OF SPONSOR AD -->
     <table
       id="Layout19"
       class="ReadMsgBody tgOuter"

--- a/utils/email-templates/render-new-tools-launch-reminder-email.ts
+++ b/utils/email-templates/render-new-tools-launch-reminder-email.ts
@@ -1,4 +1,5 @@
 import baseTemplate from '@/utils/email-templates/new-tools-launch-reminder-email-template';
+import { applyEmailSponsorAd } from '@/utils/email-templates/email-sponsor-ad';
 import { minifyEmailHtml } from '@/utils/email-templates/minify-email-html';
 
 const START_MARKER = '<!-- START OF CONTENT -->';
@@ -55,5 +56,5 @@ export function renderNewToolsLaunchReminderEmail(tools: LaunchReminderToolInput
       ? '<p style="color:#94a3b8;font-family:Helvetica,Arial,sans-serif;font-size:16px;padding:12px 15px">No tools scheduled for this launch week yet.</p>'
       : tools.map(t => fillOneToolBlock(toolBlock, t)).join('');
 
-  return minifyEmailHtml(`${before}${toolsHtml}${after}`);
+  return minifyEmailHtml(applyEmailSponsorAd(`${before}${toolsHtml}${after}`));
 }


### PR DESCRIPTION
feat: implement email sponsor ad editor

- Introduced a new API for managing email sponsor ad configurations, including GET, POST, and DELETE methods.
- Created a new page for the email sponsor ad editor, allowing users to upload images, set links, and preview changes.
- Added functionality to save and reset ad configurations, with validation for required fields and URL formats.
- Integrated the sponsor ad into the email template rendering process, enhancing the email marketing capabilities.