### PR TITLE
Submit: HomeLab Monitor - homelab dashboard with GPU/VRAM attribution

### DIFF
--- a/data/submissions/homelab-monitor-20260618.json
+++ b/data/submissions/homelab-monitor-20260618.json
@@ -1,0 +1,12 @@
+{
+  "id": "homelab-monitor",
+  "name": "HomeLab Monitor",
+  "tagline": "Homelab dashboard with per-container GPU/VRAM attribution and a built-in MCP server",
+  "description": "Self-hosted dashboard in a single Docker container. Shows which container is holding the GPU (per-container VRAM, not just total), plus Docker health and logs, systemd status, host vitals, and multiple machines over SSH. Since v0.14.0 it ships a read-only MCP server, so Claude can query your homelab directly.",
+  "url": "https://github.com/SikamikanikoBG/homelab-monitor",
+  "imageUrl": "https://raw.githubusercontent.com/SikamikanikoBG/homelab-monitor/main/docs/logo-400.png",
+  "pricing": "Open Source",
+  "categories": ["Monitoring", "DevOps", "Self-Hosted"],
+  "tags": ["monitoring", "homelab", "self-hosted", "docker", "gpu", "mcp", "open-source"],
+  "createdAt": "2026-06-18T00:00:00.000000+00:00"
+}


### PR DESCRIPTION
Adds [HomeLab Monitor](https://github.com/SikamikanikoBG/homelab-monitor) - a self-hosted homelab dashboard in a single Docker container.

The part I haven't seen elsewhere: per-container GPU/VRAM attribution - which container is actually holding the GPU, not just total utilization. If you run Ollama, ComfyUI or anything else fighting over one card, it tells you who's holding it and how much VRAM they have.

Also covers Docker container health and logs, systemd service status, host vitals (CPU/RAM/disk/temps), and multiple machines over SSH. Since v0.14.0 it ships a built-in read-only MCP server on :9810, so Claude can query the homelab directly.

- GitHub: https://github.com/SikamikanikoBG/homelab-monitor
- License: MIT (open source)
- Pricing: free / open source
- Stars: 196 (as of 2026-09-08)
- Latest: v0.31.0

Submission file: data/submissions/homelab-monitor-20260618.json