### PR TITLE
Submit: API Workbench — agent-readable API testing for Cursor, Windsurf, and VS Code

### DIFF
--- a/data/submissions/api-workbench-20260701.json
+++ b/data/submissions/api-workbench-20260701.json
@@ -1,0 +1,12 @@
+{
+  "id": "api-workbench",
+  "name": "API Workbench",
+  "tagline": "Agent-readable API testing for VS Code, Cursor, and Windsurf",
+  "description": "API Workbench is a local-first REST and HTTP API testing extension for VS Code, Cursor, and Windsurf. Write requests in plain .http files, run one request or an entire collection, and get structured agent-readable output (REQUEST/STATUS/DURATION/BODY_JSON labels) that AI coding assistants can parse and act on without scraping a webview. Collections are Git-native .http files — no cloud account, no browser UI, no vendor lock-in. Works natively in Cursor and Windsurf via Open VSX.",
+  "url": "https://github.com/sapph1re/api-workbench",
+  "imageUrl": "https://raw.githubusercontent.com/sapph1re/api-workbench/master/images/icon.png",
+  "pricing": "Free",
+  "categories": ["Developer Tools", "Testing", "AI Tools"],
+  "tags": ["api-testing", "vscode", "cursor", "windsurf", "rest-client", "http-client", "ai-coding", "open-source", "open-vsx"],
+  "createdAt": "2026-07-01T00:00:00.000000+00:00"
+}


### PR DESCRIPTION
## API Workbench

**API Workbench** is a local-first REST and HTTP API testing extension for VS Code, Cursor, and Windsurf.

Write requests in plain `.http` files, run one request or an entire collection, and get structured **agent-readable output** that AI coding assistants can parse and act on directly — no scraping a webview, no cloud account required.

### Why it matters for developers using AI coding assistants
- Postman and Thunder Client produce UI output that agents cannot easily read
- API Workbench writes labeled output (`REQUEST:`, `STATUS:`, `DURATION:`, `BODY_JSON:`) that Cursor/Windsurf agents can parse, debug, and act on
- Collections are Git-native `.http` files committed alongside your code

### Links
- GitHub: https://github.com/sapph1re/api-workbench
- Install: download `.vsix` from latest release and install via Extensions: Install from VSIX
- Available on Open VSX (works natively in Cursor and Windsurf)

### Pricing
Free / Open Source (MIT)

### Categories
Developer Tools, Testing, AI Tools